### PR TITLE
Fix cargo clippy errors. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ float-cmp = "0.5.3"
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default
-features = ["run-for-all", "prepush-hook", "run-cargo-test", "run-cargo-fmt", "run-cargo-clippy"]
+features = ["run-for-all", "precommit-hook", "run-cargo-test", "run-cargo-fmt", "run-cargo-clippy"]
 

--- a/src/algorithms/asset_fairness.rs
+++ b/src/algorithms/asset_fairness.rs
@@ -16,7 +16,7 @@ fn dot_product(a: &[f64], b: &[f64]) -> f64 {
 }
 
 impl Algorithm for AssetFairness {
-    fn allocate(&self, resources: &Vec<f64>, demands: &Vec<Vec<f64>>) -> Vec<f64> {
+    fn allocate(&self, resources: &[f64], demands: &[Vec<f64>]) -> Vec<f64> {
         let num_resources = resources.len();
         assert!(num_resources == self.prices.len());
         for demand in demands {
@@ -32,7 +32,7 @@ impl Algorithm for AssetFairness {
         for i in 0..num_resources {
             optimizer.add_constraint(
                 &coeffs,
-                &demands.iter().map(|demand| demand[i]).collect(),
+                &demands.iter().map(|demand| demand[i]).collect::<Vec<f64>>(),
                 '<',
                 resources[i],
             );
@@ -41,8 +41,8 @@ impl Algorithm for AssetFairness {
         // Every user spends the same.
         for i in 0..demands.len() - 1 {
             optimizer.add_constraint(
-                &vec![coeffs[i], coeffs[i + 1]],
-                &vec![
+                &[coeffs[i], coeffs[i + 1]],
+                &[
                     dot_product(&demands[i], &self.prices),
                     -dot_product(&demands[i + 1], &self.prices),
                 ],
@@ -52,10 +52,10 @@ impl Algorithm for AssetFairness {
         }
         optimizer.optimize("max");
 
-        return coeffs
+        coeffs
             .iter()
             .map(|var| *optimizer.solutions.get(&var).unwrap())
-            .collect();
+            .collect()
     }
 }
 

--- a/src/algorithms/ceei.rs
+++ b/src/algorithms/ceei.rs
@@ -4,7 +4,7 @@ use crate::gurobi::ffi::{GurobiOptimizer, GurobiVar};
 pub struct Ceei {}
 
 impl Algorithm for Ceei {
-    fn allocate(&self, resources: &Vec<f64>, demands: &Vec<Vec<f64>>) -> Vec<f64> {
+    fn allocate(&self, resources: &[f64], demands: &[Vec<f64>]) -> Vec<f64> {
         let num_resources = resources.len();
         for demand in demands {
             assert!(demand.len() == num_resources);
@@ -19,17 +19,17 @@ impl Algorithm for Ceei {
         for i in 0..num_resources {
             optimizer.add_constraint(
                 &coeffs,
-                &demands.iter().map(|demand| demand[i]).collect(),
+                &demands.iter().map(|demand| demand[i]).collect::<Vec<f64>>(),
                 '<',
                 resources[i],
             );
         }
         optimizer.optimize("max");
 
-        return coeffs
+        coeffs
             .iter()
             .map(|var| *optimizer.solutions.get(&var).unwrap())
-            .collect();
+            .collect()
     }
 }
 

--- a/src/algorithms/drf.rs
+++ b/src/algorithms/drf.rs
@@ -4,7 +4,7 @@ use crate::gurobi::ffi::{GurobiOptimizer, GurobiVar};
 pub struct Drf {}
 
 impl Algorithm for Drf {
-    fn allocate(&self, resources: &Vec<f64>, demands: &Vec<Vec<f64>>) -> Vec<f64> {
+    fn allocate(&self, resources: &[f64], demands: &[Vec<f64>]) -> Vec<f64> {
         let num_resources = resources.len();
         for demand in demands {
             assert!(demand.len() == num_resources);
@@ -19,7 +19,7 @@ impl Algorithm for Drf {
         for i in 0..num_resources {
             optimizer.add_constraint(
                 &coeffs,
-                &demands.iter().map(|demand| demand[i]).collect(),
+                &demands.iter().map(|demand| demand[i]).collect::<Vec<f64>>(),
                 '<',
                 resources[i],
             );
@@ -40,18 +40,18 @@ impl Algorithm for Drf {
         // Equalize dominant shares.
         for i in 0..demands.len() - 1 {
             optimizer.add_constraint(
-                &vec![coeffs[i], coeffs[i + 1]],
-                &vec![dominant_shares[i], -dominant_shares[i + 1]],
+                &[coeffs[i], coeffs[i + 1]],
+                &[dominant_shares[i], -dominant_shares[i + 1]],
                 '=',
                 0.0,
             );
         }
         optimizer.optimize("max");
 
-        return coeffs
+        coeffs
             .iter()
             .map(|var| *optimizer.solutions.get(&var).unwrap())
-            .collect();
+            .collect()
     }
 }
 

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -6,5 +6,5 @@ mod ceei;
 mod drf;
 
 pub trait Algorithm {
-    fn allocate(&self, resources: &Vec<f64>, demands: &Vec<Vec<f64>>) -> Vec<f64>;
+    fn allocate(&self, resources: &[f64], demands: &[Vec<f64>]) -> Vec<f64>;
 }


### PR DESCRIPTION
- Run `cargo clippy --all -- -D warnings` precommit instead of prepush.
- Fix errors reported by cargo clippy. 