### PR TITLE
Generate trace replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 a.out
 *.log
 *.lp
+*.denarii.data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,14 @@ edition = "2018"
 
 [dependencies]
 rand = "0.7.2"
+rand_distr = "0.2.2"
 float-cmp = "0.5.3"
 clap = "~2.27.0"
+savefile = "0.3.0"
+savefile-derive = "0.3.0"
+rustc-serialize = "0.3.24"
 
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default
 features = ["run-for-all", "precommit-hook", "run-cargo-test", "run-cargo-fmt", "run-cargo-clippy"]
-

--- a/src/algorithms/asset_fairness.rs
+++ b/src/algorithms/asset_fairness.rs
@@ -2,7 +2,7 @@ use super::Algorithm;
 use crate::gurobi::ffi::{GurobiOptimizer, GurobiVar};
 
 pub struct AssetFairness {
-    prices: Vec<f64>,
+    pub prices: Vec<f64>,
 }
 
 fn dot_product(a: &[f64], b: &[f64]) -> f64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,37 @@ mod simulator;
 
 extern crate clap;
 
+extern crate savefile;
+
+use savefile::prelude::*;
+
+#[macro_use]
+extern crate savefile_derive;
+
 use algorithms::Algorithm;
 use clap::{App, Arg};
-use rand::distributions::{Bernoulli, Distribution};
+use std::collections::HashMap;
+//use rand::distributions::{Bernoulli, Distribution};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
+use rand_distr::{Distribution, Poisson};
 use simulator::Packet;
+
+const MAX_RUN: usize = 4;
+const MAX_TRACE: usize = 10000;
 
 fn main() {
     let matches = App::new("Denarii")
         .version("0.1.0")
         .author("Taegyun Kim <k.taegyun@gmail.com>")
         .about("Discrete time based simulator for resource allocation in packet based network ddevices.")
+        .arg(
+            Arg::with_name("num_resources")
+                .short("n_r")
+                .long("num_resources")
+                .default_value("2")
+                .help("The number of resources on the hardware."),
+        )
         .arg(
             Arg::with_name("ticks")
                 .short("t")
@@ -30,48 +49,99 @@ fn main() {
                 .default_value("1")
                 .help("Random seed"),
         )
+        .arg(
+            Arg::with_name("distribution")
+                .short("dis")
+                .long("distribution")
+                .default_value("1")
+                .help("Bernoulli Distribution"), // todo: add uni, poi, bern
+        )
+        .arg(
+            Arg::with_name("runs")
+                .short("r")
+                .long("runs")
+                .default_value("1")
+                .help("The number of runs to run the simulator."),
+        )
+        
         .get_matches();
-
+    let num_resources = matches
+        .value_of("num_resources")
+        .unwrap()
+        .parse::<usize>()
+        .unwrap();
     let seed: u64 = matches.value_of("seed").unwrap().parse::<u64>().unwrap();
-    let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
+    let rng: StdRng = SeedableRng::seed_from_u64(seed);
+    let ticks = matches.value_of("ticks").unwrap().parse::<usize>().unwrap();
+    let runs = matches.value_of("runs").unwrap().parse::<usize>().unwrap();
 
-    let ticks = matches.value_of("ticks").unwrap().parse::<u64>().unwrap();
+    // TODO (mimee): Get string parsing to work.
+    let distribution_enum = matches
+        .value_of("distribution")
+        .unwrap()
+        .parse::<usize>()
+        .unwrap();
+
+    // Valid checks
+    if distribution_enum != 1 {
+        println!("Distribution has to be 1.");
+        return;
+    }
+    if runs > MAX_RUN {
+        println!("Runs has to be at most {}", MAX_RUN);
+        return;
+    }
+    if ticks > MAX_TRACE {
+        println!("Ticks has to be at most {}.", MAX_TRACE);
+    }
 
     // Packets not allocated
     let mut pkts: Vec<Packet> = Vec::new();
     let mut completed: Vec<Packet> = Vec::new();
 
-    let p = 0.3;
-    // Distribution for packet arrivals.
-    let a_dist = Bernoulli::new(p).unwrap();
-    let num_resources = 2;
+    // // Use bernoulli for now.
+    // let p = 0.3;
+    // add a switch for different distributions
 
-    // TODO: Provide ways to set initial capacity of resources, 1) commandline
-    // argument, 2) randomly generate them.
+    // Distribution for packet arrivals.
+    //let a_dist = Bernoulli::new(p).unwrap();
+
+    // TODO: Provide ways to 2) randomly generate them.
     let capacity: Vec<f64> = (0..num_resources)
         .map(|x| ((x + 1) as f64) * 10.0)
         .collect();
 
     let alg = algorithms::Drf {};
 
+    // parameters for the run
+    let mut key = HashMap::new();
+    // 1 for Poisson
+    key.insert("num_resources", num_resources);
+    key.insert("distribution", distribution_enum);
+    key.insert("ticks", ticks);
+    key.insert("runs", runs);
+
+    // truncate to ticks
+    let trace = load_trace(key, ticks as usize, rng);
+
+    println!("{}: total number in trace", trace.len());
+
+    // generate trace
     let mut num_pkts = 0;
     for t in 0..ticks {
-        let add_new_packet: bool = a_dist.sample(&mut rng);
-        // New Packet coming
-        if add_new_packet {
-            let service_time = rng.gen_range(10, 20) as f64;
-            let resource_req: Vec<f64> = (0..num_resources)
-                .map(|_| rng.gen_range(1, 11) as f64)
-                .collect();
-            println!(
-                "t:{}, service_time:{}, resource_req:{:?}",
-                t, service_time, resource_req
-            );
+        let pa: Packet = trace[t as usize].load_from_sim();
 
-            let p: Packet = Packet::new(num_pkts, t, service_time, resource_req);
-            num_pkts += 1;
-            pkts.push(p);
+        // TODO: match on tid instead of index
+        // It should be a group of packets.
+        let add_new_packet: bool = !pa.is_empty();
+        if !add_new_packet {
+            // treat the trace as a deterministic sample.
+            continue;
         }
+
+        // TODO: Poisson could give multiple arrivals per timestep
+        num_pkts += 1;
+        pkts.push(pa);
 
         // Step each packet.
         let mut done_pkts = 0;
@@ -84,7 +154,6 @@ fn main() {
                 done_pkts += 1;
             }
         }
-
         // Remove packets that are completed.
         pkts.retain(|pkt| !pkt.is_completed());
 
@@ -95,13 +164,109 @@ fn main() {
     }
 
     for pkt in &completed {
-        println!("{:?}", pkt);
+        println!("{:?} completes", pkt);
     }
 
     println!("{}: Total number of packets", num_pkts);
 }
 
-fn run_allocation(pkts: &mut [Packet], t: u64, capacity: &[f64], alg: &dyn Algorithm) {
+fn store_traces(key: HashMap<&str, usize>, traces: &Vec<Vec<Packet>>) {
+    // store based on key.dist...
+
+    // best to use parquet and interface with spark?
+    println!("{:?}", key);
+    for i in traces {
+        save_file("example_trace", 0, i).unwrap();
+    }
+    return;
+}
+
+fn generate_trace(key: &HashMap<&str, usize>, mut rng: StdRng) -> Vec<Vec<Packet>> {
+    // only generates when not in cache
+    // generate for MAX_RUN runs and MAX_TRACE ticks
+    // TODO: add type "simulated" to Packet
+    let ticks = MAX_TRACE;
+    let runs = MAX_RUN;
+    let num_resources = key["num_resources"]; // put these all in key
+
+    // todo: make this dynamic
+    // `if key.distribution = "poisson", key.lambda = 2.0`
+    let poi = Poisson::new(2.0).unwrap();
+    let dist = poi;
+    println!("Generate trace uses key {:?}", key);
+
+    let mut traces: Vec<Vec<Packet>> = Vec::new();
+    for _ in 0..runs {
+        let mut pkts: Vec<Packet> = Vec::new();
+        let mut num_pkts = 0;
+
+        for tid in 0..ticks {
+            // There may be multiple at a timestep
+            let add_new_packet: u64 = dist.sample(&mut rng);
+            println!("{} sample", add_new_packet);
+
+            // New Packet(s) coming
+            if add_new_packet > 0 {
+                for pid in 0..add_new_packet {
+                    let service_time = rng.gen_range(10, 20) as f64;
+                    let resource_req: Vec<f64> = (0..num_resources)
+                        .map(|_| rng.gen_range(1, 11) as f64)
+                        .collect();
+                    println!(
+                        "tid:{}, service_time:{}, resource_req:{:?}",
+                        tid, service_time, resource_req
+                    );
+
+                    // ID = timestep + num of packets + packet index at its time so it is strictly increasing.
+                    let pa: Packet = Packet::new(
+                        tid as u64 + num_pkts + pid as u64,
+                        tid as u64,
+                        service_time,
+                        resource_req,
+                    );
+                    num_pkts += 1;
+                    pkts.push(pa);
+                }
+            } else {
+                // At leasr 1 packet per tick?
+                // so we ought to construct an empty packet?
+                // id = tick
+                let emp: Packet = Packet::new_dummy(tid as u64);
+                pkts.push(emp);
+            }
+        }
+        traces.push(pkts);
+        println!("{} packets came from a Poisson(2) distribution", num_pkts);
+    }
+    return traces;
+}
+
+fn load_trace(key: HashMap<&str, usize>, _truncate: usize, rng: StdRng) -> Vec<Packet> {
+    // TODO: add a trace class.
+    // TODO: finalize key's fields {runs, distributions, p, lambda, ...}
+    // TODO: Load file based on key content
+    // This is not very efficient.
+    let traces: Vec<Vec<Packet>> = load_file("example_trace", 0).unwrap_or(Vec::new());
+
+    // if in cache, load it, truncate and return
+    if traces.len() > 0 {
+        println!("{}", traces.len());
+        return traces[0][0.._truncate].to_vec();
+    }
+
+    let gen_traces = generate_trace(&key, rng);
+    println!("{} runs generated", gen_traces.len());
+    println!("{} packets generated at 0th trace", gen_traces[0].len());
+
+    // if not in cache, store it
+    store_traces(key, &gen_traces);
+
+    // truncate and return the first one, if no run param given.
+    // Truncate up till arrival time < ticks, not using tid!!
+    return gen_traces[0][0.._truncate].to_vec();
+}
+
+fn run_allocation(pkts: &mut [Packet], t: usize, capacity: &[f64], alg: &dyn Algorithm) {
     let mut requests: Vec<Vec<f64>> = Vec::new();
     for pkt in pkts.iter() {
         requests.push(pkt.resource_req.clone());

--- a/src/simulator/packet.rs
+++ b/src/simulator/packet.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Savefile)]
 pub struct Packet {
     /// Packet ID
     id: u64,
@@ -30,10 +30,10 @@ impl Packet {
         }
     }
 
-    pub fn new_dummy(id: u64) -> Packet{
+    pub fn new_dummy(id: u64) -> Packet {
         Packet {
             id,
-            is_empty:true,
+            is_empty: true,
             ..Default::default()
         }
     }
@@ -53,6 +53,14 @@ impl Packet {
         self.is_completed()
     }
 
+    pub fn load_from_sim(&self) -> Packet {
+        Packet::new(
+            self.id,
+            self.t_arrival,
+            self.service_time,
+            self.resource_req.to_vec(),
+        )
+    }
     pub fn is_empty(&self) -> bool {
         self.is_empty
     }

--- a/src/simulator/packet.rs
+++ b/src/simulator/packet.rs
@@ -24,6 +24,7 @@ impl Packet {
         Packet {
             id,
             t_arrival,
+            t_departure: t_arrival,
             resource_req,
             service_time,
             ..Default::default()

--- a/src/simulator/packet.rs
+++ b/src/simulator/packet.rs
@@ -14,6 +14,9 @@ pub struct Packet {
     service_time: f64,
     /// Actual service time it has gotten so far.
     adjusted_service_time: f64,
+
+    // Dummy packet, default to false
+    is_empty: bool,
 }
 
 impl Packet {
@@ -27,6 +30,13 @@ impl Packet {
         }
     }
 
+    pub fn new_dummy(id: u64) -> Packet{
+        Packet {
+            id,
+            is_empty:true,
+            ..Default::default()
+        }
+    }
     /// Steps one tick.
     pub fn step(&mut self) -> bool {
         if !self.is_scheduled() {
@@ -41,6 +51,10 @@ impl Packet {
         self.t_departure += 1;
 
         self.is_completed()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.is_empty
     }
 
     pub fn is_completed(&self) -> bool {

--- a/src/simulator/packet.rs
+++ b/src/simulator/packet.rs
@@ -54,12 +54,14 @@ impl Packet {
     }
 
     pub fn load_from_sim(&self) -> Packet {
-        Packet::new(
+        let mut pa = Packet::new(
             self.id,
             self.t_arrival,
             self.service_time,
             self.resource_req.to_vec(),
-        )
+        );
+        pa.is_empty = self.is_empty();
+        return pa;
     }
     pub fn is_empty(&self) -> bool {
         self.is_empty


### PR DESCRIPTION
### DONE
* Throughput and other calculations enabled:
`283: Total number of packets
76: Total number of packets completed. Throughput 0.26855123674911663.`

* Add Poisson distribution for packet arrival *(with caveats)
* Interface dynamic distributions: {Poi, Bern}
* Command line supports arguments. 
Example `./target/debug/denarii --ticks 1000 --seed 20 --distribution 1 --runs 2 --num_resources 5 --algorithm 1`
* Synthesize and save traces in the file system based on given parameters.
Automatic loading and saving
So for the same keys the same traces are compared (as a feature).
* Generate traces if not already synthesized, and storing it * (with caveats).
* Truncate traces for runs of lower order.

* Packet: add dummy packet and `is_empty()` check
* Packet: add savefile and a simple copy for loading simulated item, since now packet is not clonable.

* Corresponding cargo file changes.

### TODO
* "Key" for runs clarified.

* Plot the result of runs.
* Incorporating "runs" flags in actual tests.

* Tests
* Refactors